### PR TITLE
Fix "Open in Colab" link for `Assignment1.2.ipynb`

### DIFF
--- a/Assignments/Assignment1.2.ipynb
+++ b/Assignments/Assignment1.2.ipynb
@@ -1065,7 +1065,7 @@
         "colab_type": "text"
       },
       "source": [
-        "<a href=\"https://colab.research.google.com/github/marekadamczyk44/ml_uwr/blob/main/Assignment1_2.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+        "<a href=\"https://colab.research.google.com/github/marekadamczyk44/ml_uwr/blob/main/Assignments/Assignment1.2.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
       ]
     },
     {


### PR DESCRIPTION
[shields.io](https://shields.io/)-style badge at the top of the document.