### PR TITLE
Fix typo and remove accidentally left part of solution

### DIFF
--- a/Assignments/Assignment2.2.ipynb
+++ b/Assignments/Assignment2.2.ipynb
@@ -446,7 +446,7 @@
     "    log-probabilities. Which one is better and why?\n",
     "\n",
     "    Please type a short answer below.\n",
-    "2. **[1.5p]** What is the language of the following phrases, according to the Naive Bayes classifier (whihc you have to implement in a code cell below)? Assume equal prior language probabilities $P(C)$."
+    "2. **[1.5p]** What is the language of the following phrases, according to the Naive Bayes classifier (which you have to implement in a code cell below)? Assume equal prior language probabilities $P(C)$."
    ]
   },
   {
@@ -795,8 +795,6 @@
     "\n",
     "\n",
     "x_start = [0.0, 2.0]\n",
-    "lbfsgb_ret = sopt.fmin_l_bfgs_b(\n",
-    "    rosenbrock, x_start, callback=save_hist\n",
     "lbfsgb_ret = sopt.fmin_l_bfgs_b(TODO, TODO, callback=save_hist)\n",
     "\n",
     "# TODO: plot the countours of the function and overlay the optimization trajectory\n"


### PR DESCRIPTION
Fixed a typo in question 2 in problem 1 and removed a call of sopt.fmin_l_bfgs_b in problem 2 that seemed to be accidentally left in file (bellow was the call with TODO arguments)